### PR TITLE
Allow chaining together multiple dataloader calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ query {
 }
 ```
 
+## Chaining dataloaders
+
+The `SyncDataLoader.load` function returns a `SyncFuture` object which, similar to
+a JavaScript Promise, allows you to chain results together using the
+`then(on_success: Callable)` function.
+
+For example:
+
+```python
+def get_user_name(userId: str) -> str:
+    return user_loader.load(userId).then(lambda user: user["name"])
+```
+
+You can also chain together multiple DataLoader calls:
+
+```python
+def get_best_friend_name(userId: str) -> str:
+    return (
+        user_loader.load(userId)
+        .then(lambda user: user_loader.load(user["best_friend"]))
+        .then(lambda best_friend: best_friend["name"])
+      )
+```
+
+
 ## How it works
 
 This library implements a custom version of the graphql-core

--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -1,6 +1,30 @@
+from typing import List, Callable
 from graphql.pyutils import is_collection
 
 from .sync_future import SyncFuture
+
+
+class DataloaderBatchCallbacks:
+    """
+    Singleton that stores all the batched callbacks for all dataloaders. This is
+    equivalent to the async `loop.call_soon` functionality and enables the
+    batching functionality of dataloaders.
+    """
+    _callbacks: List[Callable]
+
+    def __init__(self) -> None:
+        self._callbacks = []
+
+    def add_callback(self, callback: Callable):
+        self._callbacks.append(callback)
+
+    def run_all_callbacks(self):
+        callbacks = self._callbacks
+        while callbacks:
+            callbacks.pop(0)()
+
+
+dataloader_batch_callbacks = DataloaderBatchCallbacks()
 
 
 class SyncDataLoader:
@@ -17,7 +41,7 @@ class SyncDataLoader:
             needs_dispatch = not self._queue
             self._queue.append((key, future))
             if needs_dispatch:
-                future.deferred_callback = self.dispatch_queue
+                dataloader_batch_callbacks.add_callback(self.dispatch_queue)
             self._cache[key] = future
             return future
 


### PR DESCRIPTION
This PR changes how the dataloader batching functionality works. Rather
than trying to "detect" if a future has a "deferred_callback" in the
execution context, we create a singleton `DataLoaderBatchCallbacks`
which all dataloaders add their `dispatch_queue` functions to when
needed. We can then run all the callbacks in the execution context to
complete the SyncFuture's. This allows us to chain dataloaders together.

Fixes #6

Diff-Id: daffd
