### PR TITLE
Set USE_TZ setting in Django settings to remove warnings

### DIFF
--- a/tests/django/django_settings.py
+++ b/tests/django/django_settings.py
@@ -16,3 +16,5 @@ TEMPLATES = [
 ]
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+USE_TZ = True


### PR DESCRIPTION
Diff-Id: 86891
