### PR TITLE
Add `clear_all` and `prime` methods to SyncDataLoader

### DIFF
--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -48,6 +48,12 @@ class SyncDataLoader:
     def clear(self, key):
         self._cache.pop(key, None)
 
+    def clear_all(self):
+        self._cache.clear()
+
+    def prime(self, key, obj):
+        self._cache[key] = obj
+
     def dispatch_queue(self):
         queue = self._queue
         if not queue:


### PR DESCRIPTION
Adds `clear_all` and `prime` cache methods, which I've found useful in my app and are implemented by `aiodataloader`, but are missing from `SyncDataLoader`.