### PR TITLE
feat: use contextvars to separate batch callbacks execution between multiple threads/contexts

### DIFF
--- a/graphql_sync_dataloaders/execution_context.py
+++ b/graphql_sync_dataloaders/execution_context.py
@@ -16,10 +16,25 @@ from graphql.execution.execute import get_field_def
 from graphql.execution.values import get_argument_values
 from graphql.pyutils import AwaitableOrValue, Path, Undefined, is_iterable
 
+try:
+    from promise import Promise
+except ImportError:
+    Promise = None
+
 from .sync_dataloader import DataloaderBatchCallbacks
 from .sync_future import SyncFuture
 
 PENDING_FUTURE = object()
+
+
+if Promise is not None:
+    def _resolve_promise(obj):
+        while isinstance(obj, Promise):
+            obj = obj.get()
+        return obj
+else:
+    def _resolve_promise(obj):
+        return obj
 
 
 class DeferredExecutionContext(ExecutionContext):
@@ -55,12 +70,12 @@ class DeferredExecutionContext(ExecutionContext):
         unresolved = 0
         for response_name, field_nodes in fields.items():
             field_path = Path(path, response_name, parent_type.name)
-            result = self.execute_field(
-                parent_type, source_value, field_nodes, field_path
-            )
+            result = _resolve_promise(self.execute_field(
+                parent_type, source_value, field_nodes, field_path,
+            ))
             if isinstance(result, SyncFuture):
                 if result.done():
-                    result = result.result()
+                    result = _resolve_promise(result.result())
                     if result is not Undefined:
                         results[response_name] = result
                 else:
@@ -73,7 +88,7 @@ class DeferredExecutionContext(ExecutionContext):
                         response_name: str, result: SyncFuture, _: None
                     ) -> None:
                         nonlocal unresolved
-                        awaited_result = result.result()
+                        awaited_result = _resolve_promise(result.result())
                         if awaited_result is not Undefined:
                             results[response_name] = awaited_result
                         else:
@@ -114,23 +129,25 @@ class DeferredExecutionContext(ExecutionContext):
         info = self.build_resolve_info(field_def, field_nodes, parent_type, path)
         try:
             args = get_argument_values(field_def, field_nodes[0], self.variable_values)
-            result = resolve_fn(source, info, **args)
+            result = _resolve_promise(resolve_fn(source, info, **args))
 
             if isinstance(result, SyncFuture):
 
                 if result.done():
-                    completed = self.complete_value(
-                        return_type, field_nodes, info, path, result.result()
-                    )
-
+                    completed = _resolve_promise(self.complete_value(
+                        return_type, field_nodes, info, path, _resolve_promise(result.result()),
+                    ))
                 else:
-
                     # noinspection PyShadowingNames
                     def process_result(_: Any):
                         try:
-                            completed = self.complete_value(
-                                return_type, field_nodes, info, path, result.result()
-                            )
+                            completed = _resolve_promise(self.complete_value(
+                                return_type,
+                                field_nodes,
+                                info,
+                                path,
+                                _resolve_promise(result.result()),
+                            ))
                             if isinstance(completed, SyncFuture):
 
                                 # noinspection PyShadowingNames

--- a/graphql_sync_dataloaders/sync_dataloader.py
+++ b/graphql_sync_dataloaders/sync_dataloader.py
@@ -1,7 +1,13 @@
-from typing import List, Callable
+import contextvars
+from typing import Callable, List, Optional
+
 from graphql.pyutils import is_collection
 
 from .sync_future import SyncFuture
+
+_dataloader_batch_callbacks: contextvars.ContextVar[
+    Optional["DataloaderBatchCallbacks"]
+] = contextvars.ContextVar("dataloader_batch_callbacks", default=None)
 
 
 class DataloaderBatchCallbacks:
@@ -10,10 +16,21 @@ class DataloaderBatchCallbacks:
     equivalent to the async `loop.call_soon` functionality and enables the
     batching functionality of dataloaders.
     """
+
     _callbacks: List[Callable]
 
     def __init__(self) -> None:
+        self._token: Optional[contextvars.Token] = None
         self._callbacks = []
+
+    def __enter__(self) -> "DataloaderBatchCallbacks":
+        self._token = _dataloader_batch_callbacks.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.run_all_callbacks()
+        assert self._token is not None
+        _dataloader_batch_callbacks.reset(self._token)
 
     def add_callback(self, callback: Callable):
         self._callbacks.append(callback)
@@ -22,9 +39,6 @@ class DataloaderBatchCallbacks:
         callbacks = self._callbacks
         while callbacks:
             callbacks.pop(0)()
-
-
-dataloader_batch_callbacks = DataloaderBatchCallbacks()
 
 
 class SyncDataLoader:
@@ -41,7 +55,12 @@ class SyncDataLoader:
             needs_dispatch = not self._queue
             self._queue.append((key, future))
             if needs_dispatch:
-                dataloader_batch_callbacks.add_callback(self.dispatch_queue)
+                batch_callbacks = _dataloader_batch_callbacks.get()
+                if batch_callbacks is None:
+                    raise RuntimeError(
+                        "DeferredExecutionContext not properly configured"
+                    )
+                batch_callbacks.add_callback(self.dispatch_queue)
             self._cache[key] = future
             return future
 


### PR DESCRIPTION
I was migrating one project that I cannot yet migrate to strawberry (T_T) to graphene v3 and stumbled upon this lib as an alternative to `Promise` dataloaders.

It worked correctly, but I started getting `GraphQL deferred execution failed to complete.` when running queries concurrently. This is because the global batch callbacks object was being shared with all running contexts.

Using contextvars makes each running context (be it asyncio, threading, gevent) resolve only its own callbacks, fixing the issue